### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Klim Tsoutsman <klimusha@gmail.com>"]
 edition = "2018"
 description = "A program that stops and starts a process based on other currently open processes."
 license = "MIT"
-repository = "http://github.com/TypicalFork/mining-scheduler/"
+repository = "https://github.com/TypicalFork/mining-scheduler/"
 keywords = ["scheduler", "automation", "mining"]
 categories = ["command-line-utilities"]
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97